### PR TITLE
add options borg class

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,10 @@
+CHANGES
+
+0.2.0 (Jan 10, 2019)
+
+- setup.py now uses setuptools to facilitate use in more complex packaging environments
+- added a borg class to provide global option across PG python classes
+
+0.1.6 (Apr 21, 2017)
+
+- earliest version in version control

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "3.6"

--- a/libgutenberg/CommonOptions.py
+++ b/libgutenberg/CommonOptions.py
@@ -1,0 +1,10 @@
+# options is a "Borg" set by optparse (note that it's not thread-safe)
+class Options:
+    __shared_state = {}
+    def __init__(self):
+        self.__dict__ = self.__shared_state
+        
+    def update(self, _dict):
+        self.__dict__.update(_dict)
+
+options = Options()

--- a/libgutenberg/GutenbergDatabase.py
+++ b/libgutenberg/GutenbergDatabase.py
@@ -24,6 +24,9 @@ psycopg2.extensions.register_type (psycopg2.extensions.UNICODE)
 psycopg2.extensions.register_type (psycopg2.extensions.UNICODEARRAY)
 
 from .Logger import debug, critical
+from .CommonOptions import Options
+
+options = Options()
 
 DatabaseError  = psycopg2.DatabaseError
 IntegrityError = psycopg2.IntegrityError

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.1.6'
+__version__ = '0.2.0'
 
-from distutils.core import setup
+from setuptools import setup
 
 setup (
     name         = 'libgutenberg',
@@ -17,13 +17,10 @@ setup (
 
     install_requires = [
         'lxml',
-        # We cannot make this package dependent on psycopg2 because
-        # most users will not have postgres installed.  Thus all
-        # packages that actually use the GutenbergDatabase module will
-        # have to depend on psycopg2 themselves.
-        # 'psycopg2',
     ],
-
+    extras_require = {
+        'postgres':  ['psycopg2']
+    },
     packages = [
         'libgutenberg'
     ],
@@ -31,20 +28,20 @@ setup (
     # metadata for upload to PyPI
 
     author = "Marcello Perathoner",
-    author_email = "webmaster@gutenberg.org",
+    maintainer = "Eric Hellman",
+    maintainer_email = "eric@hellman.net",
     description = "Common files used by Project Gutenberg python projects.",
     long_description = "Useless as standalone install. Used only as requirement for other packages.",
     license = "GPL v3",
     keywords = "project gutenberg",
-    url = "http://pypi.python.org/pypi/libgutenberg/",
+    url = "https://github.com/gutenbergtools/libgutenberg/",
 
     classifiers = [
-        "Development Status :: 4 - Beta",
-        "Environment :: Console",
         "Intended Audience :: Other Audience",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 


### PR DESCRIPTION
the GutenbergDatabase class refers to an "options" class which is inserted into the PG python environment as a builtin, which seems a dangerous way to pass global settings. I have replaced it with a "borg" class defined here for use around the PG environment. Note that settings put into the borg class can be overwritten by other python threads, so be best to to ebook conversions and the like which depend on shared parameters in a single thread. This at least if preferable to what we previously had- any python code that defined "options" could conflict with the ebookmaker defined "options".