### PR TITLE
Uri

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 CHANGES
 
+0.4.0 (September 16, 2019)
+- added a constant PG_URL with the https url so we can keep the http version for RDF and XML namespacing only. This has the effect of changing dc file URLs to https. For some discussion of https in RDF, see https://www.w3.org/blog/2016/05/https-and-the-semantic-weblinked-data/ 
+
 0.3.2 (May 10, 2019)
 - fixed a missing import for internationalization. This code relied on installation of "_" into the context's builtins. If you are installing a translator into builtins, you'll also need to install it into the gettext module.
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 CHANGES
 
+0.4.1 (October 8, 2019)
+- fixed bug where creators with marcrel='aut' were not included as authors on the cover 
+
 0.4.0 (September 16, 2019)
 - added a constant PG_URL with the https url so we can keep the http version for RDF and XML namespacing only. This has the effect of changing dc file URLs to https. For some discussion of https in RDF, see https://www.w3.org/blog/2016/05/https-and-the-semantic-weblinked-data/ 
 

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -471,7 +471,7 @@ class DublinCore (object):
         num_auths = 0
         creators = []
         for author in self.authors:
-            if author.marcrel in ('cre', 'edt'):
+            if author.marcrel in ('aut', 'cre', 'edt'):
                 num_auths += 1
                 creators.append (author)
         if num_auths == 1:

--- a/libgutenberg/GutenbergDatabaseDublinCore.py
+++ b/libgutenberg/GutenbergDatabaseDublinCore.py
@@ -21,7 +21,7 @@ import datetime
 
 from . import DublinCore
 from . import GutenbergGlobals as gg
-from .GutenbergGlobals import NS, Struct
+from .GutenbergGlobals import Struct, PG_URL
 from .Logger import info, warning, error
 from .GutenbergDatabase import xl, DatabaseError, IntegrityError
 
@@ -291,7 +291,7 @@ order by filetypes.sortorder, encodings.sortorder, fk_filetypes,
                 fn = 'dirs/' + fn
 
             file_.filename    = fn
-            file_.url         = str (NS.pg) + fn
+            file_.url         = PG_URL + fn
             file_.id          = row.pk
             file_.extent      = row.filesize
             file_.hr_extent   = self.human_readable_size (row.filesize)
@@ -312,7 +312,7 @@ order by filetypes.sortorder, encodings.sortorder, fk_filetypes,
                 file_.mediatypes.append (gg.DCIMT ('application/zip'))
 
             if file_.generated and not row.fk_filetypes.startswith ('cover.'):
-                file_.url = "%sebooks/%d.%s" % (str (NS.pg), id_, row.fk_filetypes)
+                file_.url = "%sebooks/%d.%s" % (PG_URL, id_, row.fk_filetypes)
 
             self.files.append (file_)
 

--- a/libgutenberg/GutenbergGlobals.py
+++ b/libgutenberg/GutenbergGlobals.py
@@ -29,6 +29,9 @@ class Struct (object):
     """
     pass
 
+PG_CANONICAL_HOST = 'www.gutenberg.org'
+
+PG_URL = 'https://' + PG_CANONICAL_HOST + '/'
 
 NSMAP = {
     'atom':       'http://www.w3.org/2005/Atom',
@@ -38,7 +41,7 @@ NSMAP = {
     'dcam':       'http://purl.org/dc/dcam/',
     'dcmitype':   'http://purl.org/dc/dcmitype/',
     'dcterms':    'http://purl.org/dc/terms/',
-    'ebook':      'http://www.gutenberg.org/ebooks/',             # URL
+    'ebook':      'http://' + PG_CANONICAL_HOST + '/ebooks/',             # for RDF only
     'foaf':       'http://xmlns.com/foaf/0.1/',
     'marcrel':    'http://id.loc.gov/vocabulary/relators/',
     'mathml':     'http://www.w3.org/1998/Math/MathML',
@@ -47,10 +50,10 @@ NSMAP = {
     'opds':       'http://opds-spec.org/2010/Catalog',
     'opf':        'http://www.idpf.org/2007/opf',
     'opensearch': 'http://a9.com/-/spec/opensearch/1.1/',
-    'pg':         'http://www.gutenberg.org/',                    # URL
-    'pgagents':   'http://www.gutenberg.org/2009/agents/',
-    'pgtei':      'http://www.gutenberg.org/tei/marcello/0.5/ns',
-    'pgterms':    'http://www.gutenberg.org/2009/pgterms/',
+    'pg':         'http://' + PG_CANONICAL_HOST + '/',                    # for RDF only
+    'pgagents':   'http://' + PG_CANONICAL_HOST + '/2009/agents/',        # for RDF only
+    'pgtei':      'http://' + PG_CANONICAL_HOST + '/tei/marcello/0.5/ns', # for RDF only
+    'pgterms':    'http://' + PG_CANONICAL_HOST + '/2009/pgterms/',       # for RDF only
     'py':         'http://genshi.edgewall.org/',
     'rdf':        'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
     'rdfs':       'http://www.w3.org/2000/01/rdf-schema#',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.3.2'
+__version__ = '0.4.0'
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 from setuptools import setup
 


### PR DESCRIPTION
Separates the http gutenberg xml/rdf namespace URIs from the https URL preferred for the website.
For discussion of why we shouldn't just switch to https, see https://www.w3.org/blog/2016/05/https-and-the-semantic-weblinked-data/

this changes the file urls emitted by the dc objects to https. the uri's for the files (but not the ebooks) should change correspondingly, even in the emitted RDF. 