### PR TITLE
Missing numbers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,6 @@
 CHANGES
+0.6.2 (January 18, 2020)
+- add rollback for missing book id exception.
 
 0.6.1 (January 15, 2020)
 - added exception handling in store_file_in_database for missing book id.

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 CHANGES
 
+0.6.1 (January 15, 2020)
+- added exception handling in store_file_in_database for missing book id.
+
 0.6.0 (January 7, 2020)
 - added a 'first_letter' attribute to authors from the database to support linking to authorlists in the new version of PG website
 

--- a/libgutenberg/GutenbergDatabaseDublinCore.py
+++ b/libgutenberg/GutenbergDatabaseDublinCore.py
@@ -404,6 +404,7 @@ insert into files (fk_books, filename, filesize, filemtime,
 
         except IntegrityError:
             error ("Book number %s is not in database." % id_)
+            c.execute ('rollback')
 
 
     def register_coverpage (self, id_, url, code = 901):

--- a/libgutenberg/GutenbergDatabaseDublinCore.py
+++ b/libgutenberg/GutenbergDatabaseDublinCore.py
@@ -402,6 +402,9 @@ insert into files (fk_books, filename, filesize, filemtime,
         except OSError:
             error ("Cannot stat %s" % filename)
 
+        except IntegrityError:
+            error ("Book number %s is not in database." % id_)
+
 
     def register_coverpage (self, id_, url, code = 901):
         """ Register a coverpage for this ebook. """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 from setuptools import setup
 


### PR DESCRIPTION
added exception handling in store_file_in_database for missing book id. This was causing ebookconverter to fail when encountering books missing from the postgres database