### PR TITLE
improve exception catching if cairo not installed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,7 @@
 CHANGES
+0.6.3 (April 17, 2020)
+- catch OSError when importing cairocffi
+
 0.6.2 (January 18, 2020)
 - add rollback for missing book id exception.
 

--- a/libgutenberg/Cover.py
+++ b/libgutenberg/Cover.py
@@ -34,6 +34,10 @@ import sys
 try:
     import cairocffi as cairo
 except ImportError:
+    # cairocffi not available
+    pass
+except OSError:
+    # cairo not installed
     pass
 
 PY2 = sys.version_info[0] == 2

--- a/libgutenberg/Cover.py
+++ b/libgutenberg/Cover.py
@@ -33,7 +33,7 @@ import sys
 
 
 # Applications should be able to test for cairo like this:
-# from libgutenberg install Cover
+# from libgutenberg import Cover
 # cairo_is_ok = hasattr(Cover, 'cairo')
 
 try:

--- a/libgutenberg/Cover.py
+++ b/libgutenberg/Cover.py
@@ -31,6 +31,11 @@ import math
 import os
 import sys
 
+
+# Applications should be able to test for cairo like this:
+# from libgutenberg install Cover
+# cairo_is_ok = hasattr(Cover, 'cairo')
+
 try:
     import cairocffi as cairo
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 from setuptools import setup
 


### PR DESCRIPTION
Trying to import cairocffi raises an OSError, not an ImportError, if the cairo binary is not installed even thought the python package exists.(At least on Windows.)

Applications should be able to test for cairo like this:
```
from libgutenberg import Cover
cairo_is_ok = hasattr(Cover, 'cairo')
```