### PR TITLE
quell logger errors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 CHANGES
-0.6.4 (September 1, 2020)
+0.6.5 (September 1, 2020)
 - fix logger so that it handles non int ebook
 
 0.6.3 (April 17, 2020)

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,7 @@
 CHANGES
+0.6.4 (September 1, 2020)
+- fix logger so that it handles non int ebook
+
 0.6.3 (April 17, 2020)
 - catch OSError when importing cairocffi
 

--- a/libgutenberg/Logger.py
+++ b/libgutenberg/Logger.py
@@ -27,6 +27,10 @@ class CustomFormatter (logging.Formatter):
 
     def format (self, record):
         """ Add ebook no. to string format params. """
+        try:
+            ebook = int (ebook)
+        except ValueError:
+            ebook = 0
         record.ebook = ebook
         return logging.Formatter.format (self, record)
 

--- a/libgutenberg/Logger.py
+++ b/libgutenberg/Logger.py
@@ -28,10 +28,10 @@ class CustomFormatter (logging.Formatter):
     def format (self, record):
         """ Add ebook no. to string format params. """
         try:
-            ebook = int (ebook)
+            myebook = int (ebook)
         except ValueError:
-            ebook = 0
-        record.ebook = ebook
+            myebook = 0
+        record.ebook = myebook
         return logging.Formatter.format (self, record)
 
 

--- a/libgutenberg/tests/test_logger.py
+++ b/libgutenberg/tests/test_logger.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from libgutenberg.Logger import info
+from libgutenberg import Logger
+
+class TestLoggger(unittest.TestCase):
+
+    def setUp(self):
+        Logger.setup(Logger.LOGFORMAT, 'test.log')        
+
+    def test_noebook(self):
+        info('test1')
+
+    def test_intebook(self):
+        Logger.ebook = 1
+        info('test2')
+
+    def test_strebook(self):
+        Logger.ebook = 'one'
+        info('test3')
+

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.6.3'
+__version__ = '0.6.4'
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.6.4'
+__version__ = '0.6.5'
 
 from setuptools import setup
 


### PR DESCRIPTION
logger would error if ebook was set to a string