### PR TITLE
Single digit dirs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,7 @@
 CHANGES
+0.6.7 (October 25, 2020)
+- fix GutenbergGlobals.archive_dir with a special case for single digit book numbers
+
 0.6.6 (October 16, 2020)
 - add tests for the DC object. This is preparing for a new version, with ORM
 

--- a/libgutenberg/GutenbergGlobals.py
+++ b/libgutenberg/GutenbergGlobals.py
@@ -182,6 +182,8 @@ def cut_at_newline (text):
 def archive_dir (ebook):
     """ build 1/2/3/4/12345 for 12345 """
     ebook = str (ebook)
+    if len(ebook) == 1:
+        return '0/' + ebook
     a = []
     for c in ebook:
         a.append (c)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.6.6'
+__version__ = '0.6.7'
 
 from setuptools import setup
 


### PR DESCRIPTION
0.6.7 (October 25, 2020)
- fix GutenbergGlobals.archive_dir with a special case for single digit book numbers

Bug reported by Chuck Greif - the "more files" link was missing for books 1-9