### PR TITLE
Dublin core

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,9 @@
 CHANGES
+0.7.1 (May 25, 2021)
+- added GutenbergDublinCore.canonical_url to support https canonical urls distinct from the http URIs we're keeping so as not to break RDF links.
+- updated RDFa style in html head elements from archaic to less archaic (DOCTYPE and schema declarations)
+- use dublin core elements instead of dcterms where appropriate for modern metadata.
+
 0.7.0 (April 13, 2021)
 - fixed a spelling mistake
 - added an is_audiobook method

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -683,6 +683,7 @@ class GutenbergDublinCore (DublinCore):
             if m:
                 self.project_gutenberg_id = int (m.group (1))
                 self.is_format_of = str (NS.ebook) + str (self.project_gutenberg_id)
+                self.canonical_url = re.sub(r'^http:', 'https:', self.is_format_of) + '/'
 
 
         def handle_languages (self, dummy_prefix, text):

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -381,9 +381,6 @@ class DublinCore (object):
         e = ElementMaker ()
 
         head = e.head (
-            e.link (rel = "schema.DCTERMS", href = str (NS.dcterms)),
-            e.link (rel = "schema.MARCREL", href = str (NS.marcrel)),
-            profile = "http://dublincore.org/documents/2008/08/04/dc-html/",
             *w.metadata
             )
 

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -517,18 +517,18 @@ class GutenbergDublinCore (DublinCore):
         lit = writer.literal
         uri = writer.uri
 
-        lit('dcterms:publisher',  self.publisher)
-        lit('dcterms:rights',     self.rights)
+        lit('dc:publisher',  self.publisher)
+        lit('dc:rights',     self.rights)
         uri('dcterms:isFormatOf', self.is_format_of)
 
         for author in self.authors:
             if author.marcrel == 'aut' or author.marcrel == 'cre':
-                lit('dcterms:creator', author.name_and_dates)
+                lit('dc:creator', author.name_and_dates)
             else:
                 lit('marcrel:' + author.marcrel, author.name_and_dates)
 
         for subject in self.subjects:
-            lit('dcterms:subject', subject.subject, 'dcterms:LCSH')
+            lit('dc:subject', subject.subject, 'dcterms:LCSH')
 
         if self.release_date:
             lit('dcterms:created', self.release_date.isoformat(),

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -361,12 +361,12 @@ class DublinCore (object):
         lit = writer.literal
         # uri = writer.uri
 
-        lit ('dcterms:title',      self.title)
-        lit ('dcterms:source',     self.source)
+        lit ('dc:title',      self.title)
 
         for language in self.languages:
-            lit ('dcterms:language', language.id, 'dcterms:RFC4646')
+            lit ('dc:language', language.id, 'dcterms:RFC4646')
 
+        lit ('dcterms:source',     self.source)
         lit ('dcterms:modified',
              datetime.datetime.now (gg.UTC ()).isoformat (),
              'dcterms:W3CDTF')

--- a/libgutenberg/GutenbergGlobals.py
+++ b/libgutenberg/GutenbergGlobals.py
@@ -147,8 +147,8 @@ XHTML_DOCTYPE   = ("<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.1//EN' " +
 XHTML1_DOCTYPE   = ("<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.0 Strict//EN' " +
                    "'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'>")
 
-XHTML_RDFa_DOCTYPE = ("<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML+RDFa 1.0//EN' " +
-                      "'http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd'>")
+XHTML_RDFa_DOCTYPE = ("<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML+RDFa 1.1//EN' " +
+                      "'http://www.w3.org/MarkUp/DTD/xhtml-rdfa-2.dtd'>")
 
 NCX_DOCTYPE = ("<!DOCTYPE ncx PUBLIC '-//NISO//DTD ncx 2005-1//EN' " +
                "'http://www.daisy.org/z3986/2005/ncx-2005-1.dtd'>")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 
 from setuptools import setup
 


### PR DESCRIPTION
0.7.1 (May 25, 2021)
- added GutenbergDublinCore.canonical_url to support https canonical urls distinct from the http URIs we're keeping so as not to break RDF links.
- updated RDFa style in html head elements from archaic to less archaic (DOCTYPE and schema declarations)
- use dublin core elements instead of dcterms where appropriate for modern metadata.
