### PR TITLE
0.8.7 assorted changes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,11 @@
 CHANGES
+0.8.7 (September 2, 2021)
+- abandoning xhtml/RDFa style meta elements in dc.to_html()min favor of HTML5 style meta elements.
+- change psycopg2 WARNING to an INFO
+- deleted redundant log handler. Log messages were printing twice
+- set encoding for python files to UTF8; this was causing an encoding error in data sent to db.
+- fixed bug in is_same_path
+
 0.8.6 (August 25, 2021)
 - fix formatting of MARC attributes. Previously the marc formatter assumed a word boundary after the subfield indicator, but that's not aligned with the rest of the world. We have a few attribute fields with dollar amounts, but in every case the char after the $ is a digit. also # means [space] in the MARC docs. Ignore that $ means \1F in MARC docs, we'll just use $, until we make real MARC files.
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 CHANGES
 0.8.7 (September 2, 2021)
-- abandoning xhtml/RDFa style meta elements in dc.to_html()min favor of HTML5 style meta elements.
+- change xhtml/RDFa style meta elements in dc.to_html()min to of HTML5 style meta elements.
 - change psycopg2 WARNING to an INFO
 - deleted redundant log handler. Log messages were printing twice
 - set encoding for python files to UTF8; this was causing an encoding error in data sent to db.

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -56,13 +56,16 @@ class _HTML_Writer(object):
     """
 
     def __init__(self):
-        self.metadata = []
+        self.metadata = [
+            ElementMaker().link(rel="schema.dc", href="http://purl.org/dc/elements/1.1/"),
+            ElementMaker().link(rel="schema.dcterms", href="http://purl.org/dc/terms/"),
+        ]        
 
     @staticmethod
     def _what(what):
-        """ Transform dcterms:title to DCTERMS.title. """
+        """ Transform DCTERMS:title to dcterms.title. """
         what = str(what).split(':')
-        what[0] = what[0].upper()
+        what[0] = what[0].lower()
         return '.'.join(what)
 
     def literal(self, what, literal, scheme = None):
@@ -70,8 +73,6 @@ class _HTML_Writer(object):
         if literal is None:
             return
         params = {'name' : self._what(what), 'content': literal}
-        if scheme:
-            params['scheme'] = self._what(scheme)
         self.metadata.append(ElementMaker().meta(**params))
 
     def uri(self, what, uri):

--- a/libgutenberg/DublinCoreMapping.py
+++ b/libgutenberg/DublinCoreMapping.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/libgutenberg/GutenbergDatabase.py
+++ b/libgutenberg/GutenbergDatabase.py
@@ -40,7 +40,7 @@ except ImportError:
         pass
     class IntegrityError(Exception):
         pass
-    warning('Gutenberg Database is inactive because psycopg2 not installed')
+    info('Gutenberg Database is inactive because psycopg2 not installed')
 
 
 options = Options()

--- a/libgutenberg/GutenbergDatabase.py
+++ b/libgutenberg/GutenbergDatabase.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 GutenbergDatabase.py

--- a/libgutenberg/GutenbergDatabaseDublinCore.py
+++ b/libgutenberg/GutenbergDatabaseDublinCore.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/libgutenberg/GutenbergGlobals.py
+++ b/libgutenberg/GutenbergGlobals.py
@@ -348,7 +348,7 @@ def normalize_path (path):
 
 def is_same_path (path1, path2):
     """ Does path1 point to the same file as path2? """
-    return os.path.realpath (normalize (path1)) == os.path.realpath (normalize (path2))
+    return os.path.realpath (normalize_path (path1)) == os.path.realpath (normalize_path (path2))
 
 
 def string_to_filename (fn):

--- a/libgutenberg/GutenbergGlobals.py
+++ b/libgutenberg/GutenbergGlobals.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 GutenbergGlobals.py

--- a/libgutenberg/Logger.py
+++ b/libgutenberg/Logger.py
@@ -58,10 +58,13 @@ def setup(logformat, logfile=None, loglevel=logging.INFO, notifier=None):
     # StreamHandler defaults to sys.stderr
     file_handler = logging.FileHandler(logfile) if logfile else logging.StreamHandler()
     file_handler.setFormatter(CustomFormatter(logformat))
-    notify_handler = NotificationHandler(notifier=notifier)
     logger = logging.getLogger()
+    if logger.hasHandlers():
+        logger.handlers.clear()        
     logger.addHandler(file_handler)
-    logger.addHandler(notify_handler)
+    if notifier:
+        notify_handler = NotificationHandler(notifier=notifier)
+        logger.addHandler(notify_handler)
     logger.setLevel(loglevel)
     return file_handler
 

--- a/libgutenberg/Logger.py
+++ b/libgutenberg/Logger.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 Logger.py

--- a/libgutenberg/MediaTypes.py
+++ b/libgutenberg/MediaTypes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 MediaTypes.py

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.8.6'
+__version__ = '0.8.7'
 
 from setuptools import setup
 


### PR DESCRIPTION
- change xhtml/RDFa style meta elements in dc.to_html()min to of HTML5 style meta elements.
- change psycopg2 WARNING to an INFO
- deleted redundant log handler. Log messages were printing twice
- set encoding for python files to UTF8; this was causing an encoding error in data sent to db.
- fixed bug in is_same_path
