### PR TITLE
0.10.17

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 CHANGES
 0.10.17
 - handle $c and $v title subfields
+- include subfield marker removal in GutenbergGlobals.insert_breaks
 
 0.10.16 (February 15, 2023)
 - dc.update_date initialized to datetime.date.min 

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,7 @@
 CHANGES
+0.10.17
+- handle $c and $v title subfields
+
 0.10.16 (February 15, 2023)
 - dc.update_date initialized to datetime.date.min 
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,8 @@
 CHANGES
-0.10.17
+0.10.17 (March 7, 2023)
 - handle $c and $v title subfields
 - include subfield marker removal in GutenbergGlobals.insert_breaks
+- normalize capitalization of "eBook" in an error message
 
 0.10.16 (February 15, 2023)
 - dc.update_date initialized to datetime.date.min 

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -942,7 +942,7 @@ class GutenbergDublinCore(DublinCore):
             scan_txt(self, data)
 
         if self.project_gutenberg_id is None:
-            raise ValueError('This is not a Project Gutenberg ebook file.')
+            raise ValueError('This is not a Project Gutenberg eBook file.')
 
 
 # use PGDCObject if you want a DublinCoreObject that uses a database if available

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -29,7 +29,7 @@ from lxml.builder import ElementMaker
 import pycountry
 
 from . import GutenbergGlobals as gg
-from .GutenbergGlobals import NS, Struct, xpath, ROLES
+from .GutenbergGlobals import NS, Struct, xpath, ROLES, TITLE_SPLITTER as title_splitter
 from .Logger import critical, debug, error, exception, info, warning
 
 
@@ -46,7 +46,6 @@ DCMITYPES = [
     ("Dataset","Data Set"),
     ("Collection","Collection")
 ]
-title_splitter = re.compile(r'([\r\n]+|\$[bcv] )', flags=re.M)
 
 class _HTML_Writer(object):
     """ Write metadata suitable for inclusion in HTML.

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -46,7 +46,7 @@ DCMITYPES = [
     ("Dataset","Data Set"),
     ("Collection","Collection")
 ]
-title_splitter = re.compile(r'([\r\n]+|\$b )', flags=re.M)
+title_splitter = re.compile(r'([\r\n]+|\$[bcv] )', flags=re.M)
 
 class _HTML_Writer(object):
     """ Write metadata suitable for inclusion in HTML.

--- a/libgutenberg/GutenbergGlobals.py
+++ b/libgutenberg/GutenbergGlobals.py
@@ -278,9 +278,14 @@ def xmlspecialchars(s):
              .replace('<',  '&lt;')
              .replace('>',  '&gt;'))
 
+TITLE_SPLITTER =  re.compile(r'(\r?\n?\$[bcv] |[\r\n]+)', flags=re.M)
+
 def insert_breaks(s, self_closing=True):
-    """ Replace newlines with <br/>. """
-    return s.replace('\n', '<br />' if self_closing else '<br>')
+    """ Replace newlines with <br/>. 
+        This is used for marc attribute text, so also also replace subfield indicators
+    """
+    
+    return TITLE_SPLITTER.sub('<br />' if self_closing else '<br>', s)
 
 RE_NORMALIZE    = re.compile(r"\s+")
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.10.16'
+__version__ = '0.10.17'
 
 from setuptools import setup
 


### PR DESCRIPTION
- handle $c and $v title subfields
- include subfield marker removal in GutenbergGlobals.insert_breaks
- normalize capitalization of "eBook" in an error message