### PR TITLE
fix author matching

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,7 @@
 CHANGES
+0.10.23 (March 15, 2024)
+- fixed a reversion in 0.10.10 that made author name matching case sensitive.
+
 0.10.22 (February 26, 2024)
 - credits should be replaced, not appended
 - added test for credit replacement

--- a/libgutenberg/DublinCoreMapping.py
+++ b/libgutenberg/DublinCoreMapping.py
@@ -418,6 +418,8 @@ class DublinCoreObject(DublinCore.GutenbergDublinCore):
 
         def is_good_match(db_str, name):
             ''' make sure we're not matching in the middle of a name '''
+            db_str = db_str.lower()
+            name = name.lower()
             if name not in db_str:
                 return False
             [before, after] = db_str.split(name, 1)

--- a/libgutenberg/tests/test_dc.py
+++ b/libgutenberg/tests/test_dc.py
@@ -179,7 +179,7 @@ class TestDC(unittest.TestCase):
         self.assertEqual(adam.name, 'Smith, Adamx')
         adam2 = dc.get_or_create_author('Smith, Adam')
         self.assertNotEqual(adam.id, adam2.id)
-        adam3 = dc.get_or_create_author('Smith, Adamx')
+        adam3 = dc.get_or_create_author('Smith, adamx')
         self.assertEqual(adam.id, adam3.id)
         dc.session.delete(adam)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.10.22'
+__version__ = '0.10.23'
 
 from setuptools import setup
 


### PR DESCRIPTION
0.10.23 (March 15, 2024)
- fixed a reversion in 0.10.10 that made author name matching case sensitive.
