### PR TITLE
stop ignoring heading column. fixes #40

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 CHANGES
-0.10.24 (April 16, 2024)
+0.10.24 (April 22, 2024)
 - The `heading` column in the database's author-book many to many table was being ignored by much of our code. The result was that multiple authors were being listed in alphabetical order. now, the heading column is used and the first sort column for the authors of a book, and the authors other than the first author are have heading=2 (instead of the default `heading=1`) set on initial metadata load. The cataloguer can reset the heading numbers, but does not wish the order of authors other than the "main" author to be tracked in the database.
 
 0.10.23 (March 15, 2024)

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,7 @@
 CHANGES
+0.10.24 (April 16, 2024)
+- The `heading` column in the database's author-book many to many table was being ignored by much of our code. The result was that multiple authors were being listed in alphabetical order. now, the heading column is used and the first sort column for the authors of a book, and the authors other than the first author are have heading=2 (instead of the default `heading=1`) set on initial metadata load. The cataloguer can reset the heading numbers, but does not wish the order of authors other than the "main" author to be tracked in the database.
+
 0.10.23 (March 15, 2024)
 - fixed a reversion in 0.10.10 that made author name matching case sensitive.
 

--- a/libgutenberg/DublinCoreMapping.py
+++ b/libgutenberg/DublinCoreMapping.py
@@ -398,6 +398,7 @@ class DublinCoreObject(DublinCore.GutenbergDublinCore):
             book.authors[:] = []
 
         session = self.get_my_session()
+        first = True
         for dc_author in self.authors:
             author = self.get_or_create_author(dc_author.name)
             if hasattr(dc_author, 'birthdate'):
@@ -409,7 +410,13 @@ class DublinCoreObject(DublinCore.GutenbergDublinCore):
             if not role_type:
                 error("%s is not a valid role.", role_type.role)
                 continue
-            book.authors.append(BookAuthor(author=author, role_type=role_type))
+            book.authors.append(BookAuthor(
+                author=author,
+                role_type=role_type,
+                heading=1 if first else 2
+                ))
+            if first:
+                first = False
         return True
 
 

--- a/libgutenberg/GutenbergDatabaseDublinCore.py
+++ b/libgutenberg/GutenbergDatabaseDublinCore.py
@@ -85,12 +85,12 @@ select copyrighted, release_date, downloads from books where pk = %(ebook)s""",
         # http://www.loc.gov/loc.terms/relators/
 
         c.execute("""
-SELECT authors.pk as pk, author, born_floor, born_ceil, died_floor, died_ceil, fk_roles, role
+SELECT authors.pk as pk, author, born_floor, born_ceil, died_floor, died_ceil, fk_roles, role, heading
    FROM mn_books_authors
    JOIN authors ON mn_books_authors.fk_authors = authors.pk
    JOIN roles   ON mn_books_authors.fk_roles   = roles.pk
 WHERE mn_books_authors.fk_books = %(ebook)s
-ORDER BY role, author""", {'ebook': id_})
+ORDER BY heading, role, author""", {'ebook': id_})
 
         for row in c.fetchall():
             row = xl(c, row)
@@ -100,6 +100,7 @@ ORDER BY role, author""", {'ebook': id_})
             author.name           = row.author
             author.marcrel        = row.fk_roles
             author.role           = row.role
+            author.heading        = row.heading
             author.birthdate      = row.born_floor
             author.deathdate      = row.died_floor
             author.birthdate2     = row.born_ceil

--- a/libgutenberg/Models.py
+++ b/libgutenberg/Models.py
@@ -101,7 +101,7 @@ class Book(Base):
     langs = relationship('Lang', secondary='mn_books_langs')
     attributes = relationship('Attribute', order_by='Attribute.fk_attriblist',
         cascade="all, delete-orphan")
-    authors = relationship('BookAuthor', order_by='BookAuthor.role, BookAuthor.name',
+    authors = relationship('BookAuthor', order_by='BookAuthor.heading, BookAuthor.role, BookAuthor.name',
         cascade="all, delete-orphan")
     files = relationship(
         'File',

--- a/libgutenberg/tests/test_dc.py
+++ b/libgutenberg/tests/test_dc.py
@@ -62,7 +62,7 @@ class TestDC(unittest.TestCase):
         self.assertEqual(dc.marcs[0].caption, 'Title')
         self.assertEqual(dc.title, dc.title_file_as)
         self.assertEqual(len(dc.authors), 2)
-        author = dc.authors[0]
+        author, author2 = dc.authors[0:2]
         self.assertTrue(author.name.startswith("Grimm"))
         self.assertEqual(author.id, 971)
         self.assertEqual(author.marcrel, 'aut')
@@ -72,6 +72,7 @@ class TestDC(unittest.TestCase):
         self.assertEqual(author.name_and_dates, 'Grimm, Jacob, 1785-1863')
         self.assertEqual(author.webpages[0].url, 'https://en.wikipedia.org/wiki/Jacob_Grimm')
         self.assertEqual(author.aliases[0].alias, 'Grimm, Jacob Ludwig Carl')
+        self.assertEqual(author2.heading, 2)
         self.assertEqual(len(dc.subjects), 1)
         self.assertEqual(dc.subjects[0].subject, 'Fairy tales -- Germany')
         self.assertEqual(len(dc.bookshelves), 1)
@@ -248,6 +249,9 @@ class TestDCLoader(unittest.TestCase):
         dc.session.flush()
         self.assertTrue(DBUtils.ebook_exists(99999, session=dc.session))
         self.assertEqual(len(dc.book.authors), 6)
+        self.assertEqual(dc.book.authors[0].name, 'Lorem Ipsum Jr.')
+        self.assertEqual(dc.book.authors[0].heading, 1)
+        self.assertEqual(dc.book.authors[2].heading, 2)
         roles = [author.marcrel for author in dc.book.authors]
         self.assertTrue('trl' in roles)
         self.assertTrue('aui' in roles)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.10.23'
+__version__ = '0.10.24'
 
 from setuptools import setup
 


### PR DESCRIPTION
- The `heading` column in the database's author-book many to many table was being ignored by much of our code. The result was that multiple authors were being listed in alphabetical order. now, the heading column is used and the first sort column for the authors of a book, and the authors other than the first author are have heading=2 (instead of the default `heading=1`) set on initial metadata load. The cataloguer can reset the heading numbers, but does not wish the order of authors other than the "main" author to be tracked in the database.
