### PR TITLE
0.10.30

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ CHANGES
 
 0.10.25
 - properly skip authors with None as name (Python null, not the string "None")
+- improve year parsing in 260 attributes
 
 0.10.25 (May 22, 2024)
 - don't strip periods from title_no_subtitle

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 CHANGES
 
-0.10.25 (September 12, 2024)
+0.10.26 (September 12, 2024)
 - properly skip authors with None as name (Python null, not the string "None")
 - improve year parsing in 260 attributes
 - don't try to put first name first if author is a publisher.

--- a/CHANGES
+++ b/CHANGES
@@ -1,11 +1,11 @@
 CHANGES
 
-0.10.27 (September 19, 2024)
+0.10.28 (September 19, 2024)
 - properly skip authors with None as name (Python null, not the string "None")
 - improve year parsing in 260 attributes
 - don't try to put first name first if author is a publisher.
     - for multiple reasons, our author table should add a column denoting corporate entities. This is needed in order for us to make correct MARC records. (we want 110 fields, not 100 fields.)
-- 0.10.26 had a typo
+- 0.10.26 had a typo, 0.10.27 had a bug and were not deployed
 
 0.10.25 (May 22, 2024)
 - don't strip periods from title_no_subtitle

--- a/CHANGES
+++ b/CHANGES
@@ -1,11 +1,11 @@
 CHANGES
 
-0.10.29 (September 19, 2024)
+0.10.30 (September 19, 2024)
 - properly skip authors with None as name (Python null, not the string "None")
 - improve year parsing in 260 attributes
 - don't try to put first name first if author is a publisher.
     - for multiple reasons, our author table should add a column denoting corporate entities. This is needed in order for us to make correct MARC records. (we want 110 fields, not 100 fields.)
-- 0.10.26-28 had bugs discovered in testing and were not deployed
+- 0.10.26-29 had bugs discovered in testing and were not deployed
 
 0.10.25 (May 22, 2024)
 - don't strip periods from title_no_subtitle

--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,11 @@
 CHANGES
 
-0.10.26 (September 12, 2024)
+0.10.27 (September 19, 2024)
 - properly skip authors with None as name (Python null, not the string "None")
 - improve year parsing in 260 attributes
 - don't try to put first name first if author is a publisher.
     - for multiple reasons, our author table should add a column denoting corporate entities. This is needed in order for us to make correct MARC records. (we want 110 fields, not 100 fields.)
+- 0.10.26 had a typo
 
 0.10.25 (May 22, 2024)
 - don't strip periods from title_no_subtitle

--- a/CHANGES
+++ b/CHANGES
@@ -1,11 +1,11 @@
 CHANGES
 
-0.10.28 (September 19, 2024)
+0.10.29 (September 19, 2024)
 - properly skip authors with None as name (Python null, not the string "None")
 - improve year parsing in 260 attributes
 - don't try to put first name first if author is a publisher.
     - for multiple reasons, our author table should add a column denoting corporate entities. This is needed in order for us to make correct MARC records. (we want 110 fields, not 100 fields.)
-- 0.10.26 had a typo, 0.10.27 had a bug and were not deployed
+- 0.10.26-28 had bugs discovered in testing and were not deployed
 
 0.10.25 (May 22, 2024)
 - don't strip periods from title_no_subtitle

--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,10 @@
 CHANGES
 
-0.10.25
+0.10.25 (September 12, 2024)
 - properly skip authors with None as name (Python null, not the string "None")
 - improve year parsing in 260 attributes
+- don't try to put first name first if author is a publisher.
+    - for multiple reasons, our author table should add a column denoting corporate entities. This is needed in order for us to make correct MARC records. (we want 110 fields, not 100 fields.)
 
 0.10.25 (May 22, 2024)
 - don't strip periods from title_no_subtitle

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -295,7 +295,7 @@ class DublinCore(object):
         """ Generate a pretty title for ebook. """
         def surname(author):
             if author.marcrel == "pbl":
-                return author.name()
+                return author.name
             else:
                 return author.name.split(', ')[0]
 

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -294,7 +294,7 @@ class DublinCore(object):
     def make_pretty_title(self, size = 80, cut_nonfiling = False):
         """ Generate a pretty title for ebook. """
         def surname(author):
-            if author.marcrel == "publ":
+            if author.marcrel == "pbl":
                 return author.name()
             else:
                 return author.name.split(', ')[0]

--- a/libgutenberg/DublinCore.py
+++ b/libgutenberg/DublinCore.py
@@ -253,7 +253,7 @@ class DublinCore(object):
 
     @staticmethod
     def make_pretty_name(name, role='aut'):
-        if role in {'publ'}:
+        if role in {'pbl'}:
             return name
         """ Reverse author name components """
         rev = ' '.join(reversed(name.split(', ')))

--- a/libgutenberg/DublinCoreMapping.py
+++ b/libgutenberg/DublinCoreMapping.py
@@ -114,8 +114,8 @@ class DublinCoreObject(DublinCore.GutenbergDublinCore):
                 for c_year in s.split('$c')[1].split('$')[0].split(','):
                     year_match = RE_YEARS.search(c_year)
                     if year_match:
-                        yrtype = year_match.group(1).strip() if year_match.group(1).strip() else 'copyright'
-                        years.append((yrtype, year_match.group(2)))
+                        yrtype = year_match.group(1).strip('\r\t\n []') if year_match.group(1).strip('\r\t\n []') else 'copyright'
+                        yrtype = 'copyright' if yrtype.lower() == 'c' else yrtype
                 s = s.split('$c')[0]
             if '$b' in s:
                 publisher = s.split('$b')[1].split('$')[0].strip(' :,.;[]')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.10.27'
+__version__ = '0.10.28'
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.10.26'
+__version__ = '0.10.27'
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.10.25'
+__version__ = '0.10.26'
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.10.28'
+__version__ = '0.10.29'
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.10.29'
+__version__ = '0.10.30'
 
 from setuptools import setup
 


### PR DESCRIPTION
libgutenberg 0.10.30 (September 19, 2024)
- properly skip authors with None as name (Python null, not the string "None")
- improve year parsing in 260 attributes
- don't try to put first name first if author is a publisher.
    - for multiple reasons, our author table should add a column denoting corporate entities. This is needed in order for us to make correct MARC records. (we want 110 fields, not 100 fields.)
- 0.10.26-29 had bugs discovered in testing and were not deployed