### PR TITLE
3 lang codes, fix missing pubinfo year

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 CHANGES
 
-0.10.31 wip
-- change the language codes from 3-letter to 2. Related to https://github.com/gutenbergtools/ebookmaker/issues/243
+0.10.31 (December 30, 2024)
+- change 3 language codes from 3-letter to 2. Related to https://github.com/gutenbergtools/ebookmaker/issues/243
 - fix bug in PubInfo.__str__ that was omitting the year. Fixes https://github.com/gutenbergtools/ebookmaker/issues/245
 - update tests
 

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ CHANGES
 0.10.31 wip
 - change the language codes from 3-letter to 2. Related to https://github.com/gutenbergtools/ebookmaker/issues/243
 - fix bug in PubInfo.__str__ that was omitting the year. Fixes https://github.com/gutenbergtools/ebookmaker/issues/245
+- update tests
 
 0.10.30 (September 19, 2024)
 - properly skip authors with None as name (Python null, not the string "None")

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 CHANGES
 
+0.10.31 wip
+- change the language codes from 3-letter to 2. Related to https://github.com/gutenbergtools/ebookmaker/issues/243
+- fix bug in PubInfo.__str__ that was omitting the year. Fixes https://github.com/gutenbergtools/ebookmaker/issues/245
+
 0.10.30 (September 19, 2024)
 - properly skip authors with None as name (Python null, not the string "None")
 - improve year parsing in 260 attributes

--- a/libgutenberg/DublinCoreMapping.py
+++ b/libgutenberg/DublinCoreMapping.py
@@ -116,6 +116,7 @@ class DublinCoreObject(DublinCore.GutenbergDublinCore):
                     if year_match:
                         yrtype = year_match.group(1).strip('\r\t\n []') if year_match.group(1).strip('\r\t\n []') else 'copyright'
                         yrtype = 'copyright' if yrtype.lower() == 'c' else yrtype
+                        years.append((yrtype, year_match.group(2)))
                 s = s.split('$c')[0]
             if '$b' in s:
                 publisher = s.split('$b')[1].split('$')[0].strip(' :,.;[]')

--- a/libgutenberg/GutenbergGlobals.py
+++ b/libgutenberg/GutenbergGlobals.py
@@ -125,6 +125,7 @@ class language_map(object):
         'Cambodian': 'km',
         'Laothian': 'lo',
         'Malay': 'ms',
+        'Navajo': 'nv',
         'Nepali': 'ne',
         'Occitan': 'oc',
         'Oriya': 'or',
@@ -150,10 +151,10 @@ class language_map(object):
         'Mayan Languages': 'myn',
         'Iroquoian': 'iro',
         'Napoletano-Calabrese': 'nap',
-        'Gaelic, Scottish': 'gla',
+        'Gaelic, Scottish': 'gd',
         'Gaelic, Irish': 'gle',
         'Greek, Ancient': 'grc',
-        'Ojibwa, Western': 'ojw',
+        'Ojibwa, Western': 'oj',
         'Bodo': 'brx',
     }
 

--- a/libgutenberg/tests/test_dc.py
+++ b/libgutenberg/tests/test_dc.py
@@ -75,7 +75,7 @@ class TestDC(unittest.TestCase):
         self.assertEqual(author2.heading, 2)
         self.assertEqual(len(dc.subjects), 1)
         self.assertEqual(dc.subjects[0].subject, 'Fairy tales -- Germany')
-        self.assertEqual(len(dc.bookshelves), 1)
+        self.assertEqual(len(dc.bookshelves), 3)
         self.assertEqual(dc.bookshelves[0].bookshelf, 'DE Kinderbuch')
         self.assertEqual(dc.loccs[0].locc, 'Geography, Anthropology, Recreation: Folklore')
         self.assertEqual(dc.dcmitypes[0].id, 'Sound')
@@ -84,7 +84,7 @@ class TestDC(unittest.TestCase):
     def metadata_test2(self, dc2):
         dc2.load_from_database(self.ebook2)
         self.assertEqual('en', dc2.languages[0].id)
-        self.assertEqual(len(dc2.bookshelves), 5)
+        self.assertEqual(len(dc2.bookshelves), 9)
         self.assertEqual(dc2.bookshelves[0].bookshelf, 'Napoleonic(Bookshelf)')
         self.assertEqual(dc2.dcmitypes[0].id, 'Text')
 
@@ -102,7 +102,7 @@ class TestDC(unittest.TestCase):
     def files_test1(self, dc):
         dc.load_from_database(self.ebook)
         self.assertTrue(dc.new_filesystem)
-        self.assertEqual(len(dc.files) , 159)
+        self.assertEqual(len(dc.files) , 161)
         self.assertEqual(dc.files[0].archive_path, '2/0/0/5/20050/20050-readme.txt')
         self.assertEqual(dc.files[0].url, 'https://www.gutenberg.org/files/20050/20050-readme.txt')
         self.assertTrue(dc.files[0].extent, True)
@@ -115,7 +115,7 @@ class TestDC(unittest.TestCase):
         self.assertEqual(dc.files[0].filetype, 'readme')
         self.assertTrue('Readme' in dc.filetypes)
         self.assertEqual(dc.files[0].mediatypes[-1].mimetype, 'text/plain')
-        self.assertEqual(len(dc.mediatypes), 6)
+        self.assertEqual(len(dc.mediatypes), 7)
         self.assertTrue('audio/ogg' in dc.mediatypes)
 
     def files_test2(self, dc2):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # libgutenberg setup.py
 #
 
-__version__ = '0.10.30'
+__version__ = '0.10.31'
 
 from setuptools import setup
 


### PR DESCRIPTION
0.10.31 (December 30, 2024)
- change 3 language codes from 3-letter to 2. Related to https://github.com/gutenbergtools/ebookmaker/issues/243
- fix bug in PubInfo.__str__ that was omitting the year. Fixes https://github.com/gutenbergtools/ebookmaker/issues/245
- update tests
