### PR TITLE
Add an icon to the cover generation to indicate an audiobook or music

### DIFF
--- a/libgutenberg/Cover.py
+++ b/libgutenberg/Cover.py
@@ -31,20 +31,33 @@ import math
 import os
 import sys
 
+# Handle imports for both package and standalone usage
+try:
+    from .DublinCore import DublinCore
+except (ImportError, ValueError):
+    # If relative import fails, try adding parent directory to path
+    try:
+        from libgutenberg.DublinCore import DublinCore
+    except ModuleNotFoundError:
+        # Last resort: add parent directory to path
+        parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        if parent_dir not in sys.path:
+            sys.path.insert(0, parent_dir)
+        from libgutenberg.DublinCore import DublinCore
+
 
 # Applications should be able to test for cairo like this:
 # from libgutenberg import Cover
 # cairo_is_ok = hasattr(Cover, 'cairo')
 
+cairo = None
 try:
     import cairocffi as cairo
 except ImportError:
     print("cairocffi not available")
-    pass
 except OSError:
     # cairo not installed
     print("cairo not installed")
-    pass
 
 PY2 = sys.version_info[0] == 2
 if PY2:
@@ -624,7 +637,7 @@ def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg", au
         y = cover_height * 0.9
         cover_image.text(branding, x, y, width / 2, height, white, branding_font)
 
-        # If it is an audio book, add a speaker icon to the cover.
+        # If it is an audio book, add a speaker or music icon to the cover.
         if audio > 0:
             if audio == 2:
                 audio_char = "🎶"
@@ -671,18 +684,24 @@ def main():
     image generation.
     """
     # Helper function.
-    def _draw_and_save(title, subtitle, author, filename):
+    def _draw_and_save(title, subtitle, author, filename, audio=0):
         """
         Draw a cover and write it to a file. Note that only PNG is supported.
         """
-        cover_image = draw(title, subtitle, author)
+        dc_instance = DublinCore()
+        for a in author.split(","):
+            dc_instance.add_author(a)
+        dc_instance.title = title
+        dc_instance.subtitle = subtitle
+
+        cover_image = draw(dc_instance, audio=audio)
         if filename == "-":
             assert not "Implement."
         else:
             _, ext = os.path.splitext(os.path.basename(filename))
             if ext.upper() == ".PNG":
                 try:
-                    with open(filename, "wb") as f:
+                    with open(filename, "wb+") as f:
                         cover_image.save(f)
                 except FileNotFoundError:
                     print("Error opening target file " + filename)
@@ -701,6 +720,8 @@ def main():
     parser.add_argument("-a", "--author", dest="author", help="Author(s) of the book")
     parser.add_argument("-o", "--cover", dest="outfile", help="Filename of the cover image in PNG format")
     parser.add_argument("-j", "--json-covers", dest="json_covers", help="JSON file containing cover information")
+    parser.add_argument("--audio", dest="audio", help="Include audio icon in the cover image", action="store_true")
+    parser.add_argument("--music", dest="music", help="Include music icon in the cover image", action="store_true")
     args = parser.parse_args()
 
     # A JSON file is given as command line parameter; ignore the other ones.
@@ -715,11 +736,16 @@ def main():
                 for line in f:
                     data = json.loads(line)
                     print("Generating cover for " + data["identifier"])
+                    if args.audio:
+                        data["audio"] = 1
+                    elif args.music:
+                        data["audio"] = 2
                     status = _draw_and_save(
                         data["title"],
                         data["subtitle"],
                         data["authors"],
-                        data["filename"]
+                        data["filename"],
+                        data.get("audio", 0),
                     )
                     if status:
                         print("Error generating book cover image, skipping")
@@ -736,7 +762,12 @@ def main():
         elif not args.outfile:
             print("No outfile specified, exiting")
         else:
-            return _draw_and_save(args.title, args.subtitle, args.author, args.outfile)
+            audio = 0
+            if args.audio:
+                audio = 1
+            elif args.music:
+                audio = 2
+            return _draw_and_save(args.title, args.subtitle, args.author, args.outfile, audio)
     return 1
 
 

--- a/libgutenberg/Cover.py
+++ b/libgutenberg/Cover.py
@@ -323,8 +323,14 @@ def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg", au
     """
     Main drawing function, which generates a cover of the given dimension and
     renders title, author, and graphics.
+
+    Args:
+        audio (int, optional): Display icon on cover. Defaults to 0.
+            0 = none
+            1 = audiobook (speaker)
+            2 = music (notes)
     """
-    
+
     # pull cover strings from DublinCore object
     title = dc.title_no_subtitle
     subtitle = dc.subtitle
@@ -649,6 +655,7 @@ def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg", au
                 cairo.FONT_SLANT_NORMAL,
                 cairo.FONT_WEIGHT_NORMAL
             )
+            # Plain Noto does not work for the audio icons, so use Noto Emoji instead.
             audio_font = cover_image.font("Noto Emoji", audio_font_properties)
             audio_height = audio_font_size
             width = audio_height + 100

--- a/libgutenberg/Cover.py
+++ b/libgutenberg/Cover.py
@@ -31,20 +31,6 @@ import math
 import os
 import sys
 
-# Handle imports for both package and standalone usage
-try:
-    from .DublinCore import DublinCore
-except (ImportError, ValueError):
-    # If relative import fails, try adding parent directory to path
-    try:
-        from libgutenberg.DublinCore import DublinCore
-    except ModuleNotFoundError:
-        # Last resort: add parent directory to path
-        parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        if parent_dir not in sys.path:
-            sys.path.insert(0, parent_dir)
-        from libgutenberg.DublinCore import DublinCore
-
 
 # Applications should be able to test for cairo like this:
 # from libgutenberg import Cover
@@ -682,16 +668,19 @@ def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg", au
     return cover_image
 
 
-# The main function allows to run the cover generation to run as a standalone
+# The main function allows running the cover generation as a standalone
 # command-line tool. Arguments can be passed, use -h or --help to get a list
 # of available switches. The generated book cover is saved as an image file.
-#
-
 def main():
     """
     The main() function handles command line arguments and maneuvers the cover
     image generation.
     """
+    parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if parent_dir not in sys.path:
+        sys.path.insert(0, parent_dir)
+    from libgutenberg.DublinCore import DublinCore
+
     # Helper function.
     def _draw_and_save(title, subtitle, author, filename, audio=None):
         """

--- a/libgutenberg/Cover.py
+++ b/libgutenberg/Cover.py
@@ -62,6 +62,10 @@ except OSError:
 PY2 = sys.version_info[0] == 2
 if PY2:
     FileNotFoundError = IOError
+
+AUDIOBOOK = 1
+MUSIC = 2
+
 #
 # Private helper functions.
 #
@@ -319,14 +323,14 @@ def _clip(value, lower, upper):
 # an Image instance which is a composition of different Cairo functionality.
 #
 
-def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg", audio=0):
+def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg", audio=None):
     """
     Main drawing function, which generates a cover of the given dimension and
     renders title, author, and graphics.
 
     Args:
-        audio (int, optional): Display icon on cover. Defaults to 0.
-            0 = none
+        audio (int, optional): Display icon on cover. Defaults to None.
+            None = none
             1 = audiobook (speaker)
             2 = music (notes)
     """
@@ -573,13 +577,13 @@ def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg", au
 
     # Allocate fonts for the title and the author, and draw the text.
     
-    def drawText(audio=0):
+    def drawText(audio=None):
         """
         Args:
-            audio (int, optional): Display icon on cover. Defaults to 0.
-                0 = none
-                1 = audiobook (speaker)
-                2 = music (notes)
+            audio (int, optional): Display icon on cover. Defaults to None.
+                None = no icon
+                AUDIOBOOK = speaker icon
+                MUSIC = musical notes icon
         """
         fill = Image.colorRGB(50, 50, 50)
         white = Image.colorRGB(255, 255, 255)
@@ -644,8 +648,8 @@ def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg", au
         cover_image.text(branding, x, y, width / 2, height, white, branding_font)
 
         # If it is an audio book, add a speaker or music icon to the cover.
-        if audio > 0:
-            if audio == 2:
+        if audio in (AUDIOBOOK, MUSIC):
+            if audio == MUSIC:
                 audio_char = "🎶"
             else:
                 audio_char = "🔊"
@@ -678,8 +682,6 @@ def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg", au
     return cover_image
 
 
-# IMPORTANT: the main function does not work, because the parameters to the draw() function have changed.
-#
 # The main function allows to run the cover generation to run as a standalone
 # command-line tool. Arguments can be passed, use -h or --help to get a list
 # of available switches. The generated book cover is saved as an image file.
@@ -691,7 +693,7 @@ def main():
     image generation.
     """
     # Helper function.
-    def _draw_and_save(title, subtitle, author, filename, audio=0):
+    def _draw_and_save(title, subtitle, author, filename, audio=None):
         """
         Draw a cover and write it to a file. Note that only PNG is supported.
         """
@@ -727,8 +729,8 @@ def main():
     parser.add_argument("-a", "--author", dest="author", help="Author(s) of the book")
     parser.add_argument("-o", "--cover", dest="outfile", help="Filename of the cover image in PNG format")
     parser.add_argument("-j", "--json-covers", dest="json_covers", help="JSON file containing cover information")
-    parser.add_argument("--audio", dest="audio", help="Include audio icon in the cover image", action="store_true")
-    parser.add_argument("--music", dest="music", help="Include music icon in the cover image", action="store_true")
+    parser.add_argument("--audio", help="Include audio icon in the cover image", action="store_true")
+    parser.add_argument("--music", help="Include music icon in the cover image", action="store_true")
     args = parser.parse_args()
 
     # A JSON file is given as command line parameter; ignore the other ones.
@@ -744,15 +746,15 @@ def main():
                     data = json.loads(line)
                     print("Generating cover for " + data["identifier"])
                     if args.audio:
-                        data["audio"] = 1
+                        data["audio"] = AUDIOBOOK
                     elif args.music:
-                        data["audio"] = 2
+                        data["audio"] = MUSIC
                     status = _draw_and_save(
                         data["title"],
                         data["subtitle"],
                         data["authors"],
                         data["filename"],
-                        data.get("audio", 0),
+                        data.get("audio", None),
                     )
                     if status:
                         print("Error generating book cover image, skipping")
@@ -769,11 +771,11 @@ def main():
         elif not args.outfile:
             print("No outfile specified, exiting")
         else:
-            audio = 0
+            audio = None
             if args.audio:
-                audio = 1
+                audio = AUDIOBOOK
             elif args.music:
-                audio = 2
+                audio = MUSIC
             return _draw_and_save(args.title, args.subtitle, args.author, args.outfile, audio)
     return 1
 

--- a/libgutenberg/Cover.py
+++ b/libgutenberg/Cover.py
@@ -35,15 +35,7 @@ import sys
 # Applications should be able to test for cairo like this:
 # from libgutenberg import Cover
 # cairo_is_ok = hasattr(Cover, 'cairo')
-
-cairo = None
-try:
-    import cairocffi as cairo
-except ImportError:
-    print("cairocffi not available")
-except OSError:
-    # cairo not installed
-    print("cairo not installed")
+import cairocffi as cairo
 
 PY2 = sys.version_info[0] == 2
 if PY2:

--- a/libgutenberg/Cover.py
+++ b/libgutenberg/Cover.py
@@ -39,10 +39,11 @@ import sys
 try:
     import cairocffi as cairo
 except ImportError:
-    # cairocffi not available
+    print("cairocffi not available")
     pass
 except OSError:
     # cairo not installed
+    print("cairo not installed")
     pass
 
 PY2 = sys.version_info[0] == 2
@@ -305,7 +306,7 @@ def _clip(value, lower, upper):
 # an Image instance which is a composition of different Cairo functionality.
 #
 
-def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg"):
+def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg", audio=0):
     """
     Main drawing function, which generates a cover of the given dimension and
     renders title, author, and graphics.
@@ -553,7 +554,14 @@ def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg"):
 
     # Allocate fonts for the title and the author, and draw the text.
     
-    def drawText():
+    def drawText(audio=0):
+        """
+        Args:
+            audio (int, optional): Display icon on cover. Defaults to 0.
+                0 = none
+                1 = audiobook (speaker)
+                2 = music (notes)
+        """
         fill = Image.colorRGB(50, 50, 50)
         white = Image.colorRGB(255, 255, 255)
 
@@ -616,6 +624,26 @@ def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg"):
         y = cover_height * 0.9
         cover_image.text(branding, x, y, width / 2, height, white, branding_font)
 
+        # If it is an audio book, add a speaker icon to the cover.
+        if audio > 0:
+            if audio == 2:
+                audio_char = "🎶"
+            else:
+                audio_char = "🔊"
+            audio_font_size = cover_width * 0.4
+            audio_font_properties = (
+                audio_font_size,
+                cairo.FONT_SLANT_NORMAL,
+                cairo.FONT_WEIGHT_NORMAL
+            )
+            audio_font = cover_image.font("Noto Emoji", audio_font_properties)
+            audio_height = audio_font_size
+            width = audio_height + 100
+            height = audio_height
+            x = (cover_width - width) / 2 + 75
+            y = (cover_height - height) / 2 + 50
+            cover_image.text(audio_char, x, y, width, height, fill, audio_font)
+
     # Create the new cover image.
     cover_margin = 2
     cover_image = Image(cover_width, cover_height)
@@ -624,12 +652,13 @@ def draw(dc, cover_width=400, cover_height=600, branding="Project Gutenberg"):
     shape_color, base_color = processColors()
     drawBackground()
     drawArtwork()
-    drawText()
+    drawText(audio=audio)
 
     # Return the cover Image instance.
     return cover_image
 
 
+# IMPORTANT: the main function does not work, because the parameters to the draw() function have changed.
 #
 # The main function allows to run the cover generation to run as a standalone
 # command-line tool. Arguments can be passed, use -h or --help to get a list

--- a/libgutenberg/tests/test_cover.py
+++ b/libgutenberg/tests/test_cover.py
@@ -8,6 +8,7 @@ import unittest
 from libgutenberg import Cover
 from libgutenberg.DublinCore import DublinCore as dc
 
+# Note: cairocffi must be installed for this test to run. If it is not installed, the test will be skipped.
 @unittest.skipIf(not 'cairo' in dir(Cover), 'cover generator not configured')
 class TestMakeCovers(unittest.TestCase):
 
@@ -20,7 +21,7 @@ class TestMakeCovers(unittest.TestCase):
 
     def test_cover(self):
         try:
-            cover_image = Cover.draw(self.dc)
+            cover_image = Cover.draw(self.dc, audio=1)
             with open(self.test_path, 'wb+') as cover:
                 cover_image.save(cover)
             self.assertTrue(os.path.exists(self.test_path))
@@ -30,5 +31,6 @@ class TestMakeCovers(unittest.TestCase):
             return None
 
     def tearDown(self):
-        if os.path.exists(self.test_path):
-            os.remove(self.test_path)
+        pass
+        #if os.path.exists(self.test_path):
+        #    os.remove(self.test_path)

--- a/libgutenberg/tests/test_cover.py
+++ b/libgutenberg/tests/test_cover.py
@@ -31,4 +31,5 @@ class TestMakeCovers(unittest.TestCase):
             return None
 
     def tearDown(self):
-        pass
+        if os.path.exists(self.test_path):
+            os.remove(self.test_path)

--- a/libgutenberg/tests/test_cover.py
+++ b/libgutenberg/tests/test_cover.py
@@ -32,5 +32,3 @@ class TestMakeCovers(unittest.TestCase):
 
     def tearDown(self):
         pass
-        #if os.path.exists(self.test_path):
-        #    os.remove(self.test_path)


### PR DESCRIPTION
See ebookconverter [issue #73](https://github.com/gutenbergtools/ebookconverter/issues/73).

Added new option to the draw() function:
```
        audio (int, optional): Display icon on cover. Defaults to 0.
            0 = none
            1 = audiobook (speaker)
            2 = music (notes)
```
Examples:
<img width="400" height="600" alt="moby-audio" src="https://github.com/user-attachments/assets/463ee258-5849-4997-865e-55664f89082e" />
<img width="400" height="600" alt="moby-music" src="https://github.com/user-attachments/assets/e4d8cf01-9068-49ff-867d-17c30cc332a8" />
